### PR TITLE
Allow to optionally return a blob and save excel as an HTML table

### DIFF
--- a/addon/services/csv.js
+++ b/addon/services/csv.js
@@ -17,8 +17,11 @@ export default Service.extend({
     options = optionize(options, defaultConfig);
 
     let csv = this.jsonToCsv(data, options);
-
-    saveAs(new Blob([csv],{type:"data:text/csv;charset=utf-8"}), options.fileName);
+    let blobToSave = new Blob([csv],{type:"data:text/csv;charset=utf-8"});
+    saveAs(blobToSave, options.fileName);
+    if (options.returnBlob) {
+      return blobToSave;
+    }
   },
 
   jsonToCsv(objArray, options) {

--- a/addon/services/excel.js
+++ b/addon/services/excel.js
@@ -84,7 +84,13 @@ export default Service.extend({
 
     let wbout = XLSX.write(wb, {bookType:'xlsx', bookSST:true, type: 'binary'});
 
-    saveAs(new Blob([s2ab(wbout)],{type:"application/octet-stream"}), options.fileName);
+    let blobToSave = new Blob([s2ab(wbout)],{type:"application/octet-stream"});
+
+    saveAs(blobToSave, options.fileName);
+
+    if (options.returnBlob) {
+      return blobToSave;
+    }
 
   }
 

--- a/addon/services/excel.js
+++ b/addon/services/excel.js
@@ -74,13 +74,20 @@ export default Service.extend({
         }
       });
     } else {
-      // Add a single worksheet to workbook
-      wb.SheetNames.push(options.sheetName);
-      wb.Sheets[options.sheetName] = sheet_from_array_of_arrays(data);
-      if (options.merges && options.merges.length) {
-        wb.Sheets[options.sheetName]['!merges'] = options.merges;
+      let sheetName = options.sheetName || 'Sheet 1';
+      if (options.isHTMLTable) {
+        wb = XLSX.utils.table_to_book(data, {sheet:sheetName, display: options.display});
+      } else {
+        // Add a single worksheet to workbook
+        wb.SheetNames.push(sheetName);
+        wb.Sheets[sheetName] = sheet_from_array_of_arrays(data);
+        if (options.merges && options.merges.length) {
+          wb.Sheets[sheetName]['!merges'] = options.merges;
+        }
       }
     }
+
+    
 
     let wbout = XLSX.write(wb, {bookType:'xlsx', bookSST:true, type: 'binary'});
 


### PR DESCRIPTION
I found it helpful in a project that I was working on to optionally return the result as a Blob. This helps to save the file on native devices using cordova file save. Also added the ability to optionally use XLSX table_to_book feature to directly convert an HTML table when exporting as excel.