### PR TITLE
Add options for downloading and returning generated blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ the dependency on `ember-select-list`, which hasn't been updated in a long time
 - [v0.4.0] The `csv` service supports a new `raw` option, which disables quoting and escaping of cell contents
 - [v0.5.0] The `csv` service supports a new `autoQuote` option, which only quotes/escapes cells which need it
 (those containing quotes, commas or newlines).
+- [unreleased] Both services can optionally return the generated blob instead of (or as well as) downloading it
 
 
 Compatibility

--- a/addon/services/csv.js
+++ b/addon/services/csv.js
@@ -3,6 +3,8 @@ import { saveAs } from 'file-saver';
 import optionize from '../utils/utils';
 
 const defaultConfig = {
+  download: true,
+  returnBlob: false,
   fileName: 'export.csv',
   raw: false,
   separator: ',',
@@ -17,11 +19,14 @@ export default class CsvService extends Service {
     options = optionize(options, defaultConfig);
 
     let csv = this.jsonToCsv(data, options);
+    let output = new Blob([csv], { type: 'data:text/csv;charset=utf-8' });
 
-    saveAs(
-      new Blob([csv], { type: 'data:text/csv;charset=utf-8' }),
-      options.fileName
-    );
+    if (options.download) {
+      saveAs(output, options.fileName);
+    }
+    if (options.returnBlob) {
+      return output;
+    }
   }
 
   jsonToCsv(objArray, options) {

--- a/addon/services/excel.js
+++ b/addon/services/excel.js
@@ -5,6 +5,8 @@ import optionize from '../utils/utils';
 
 const defaultConfig = {
   sheetName: 'Sheet1',
+  download: true,
+  returnBlob: false,
   fileName: 'export.xlsx',
   multiSheet: false,
 };
@@ -108,9 +110,13 @@ export default class ExcelService extends Service {
       type: 'binary',
     });
 
-    saveAs(
-      new Blob([s2ab(wbout)], { type: 'application/octet-stream' }),
-      options.fileName
-    );
+    let output = new Blob([s2ab(wbout)], { type: 'application/octet-stream' });
+    
+    if (options.download) {
+      saveAs(output, options.fileName);
+    }
+    if (options.returnBlob) {
+      return output;
+    }
   }
 }


### PR DESCRIPTION
Adds new options to choose whether the blob is downloaded, returned or both.  Thanks to @colenso for the idea (in #9); in this version, the download is also optional.  By default, the download will be triggered as before.