### PR TITLE
Excel: Add support for HTML tables as sheet data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ the dependency on `ember-select-list`, which hasn't been updated in a long time
 - [v0.4.0] The `csv` service supports a new `raw` option, which disables quoting and escaping of cell contents
 - [v0.5.0] The `csv` service supports a new `autoQuote` option, which only quotes/escapes cells which need it
 (those containing quotes, commas or newlines).
+- [unreleased] The `excel` service accepts either a nested array or an `HTMLTableElement` as data for any sheet
 
 
 Compatibility
@@ -39,11 +40,12 @@ ember install ember-spreadsheet-export
 
 ## Usage
 
- - uses js-xlsx library for rendering excel content.
- - automatically injects a service for both excel and csv format
- - feed a datastructure that's an array of arrays, where each internal array is the set of data to be rendered for that row.
- - Example: [['Title 1', 'Title 2', 'Title 3'],['row1cell1', 'row1cell2', 'row1cell3'],['row2cell1', 'row2cell2', 'row2cell3']]
- 
+ - Inject the service(s) for Excel and/or CSV formats, depending on your needs.
+ - Feed a datastructure that's an array of arrays, where each internal array is the set of data to be rendered for that row.
+   - Example: `[['Title 1', 'Title 2', 'Title 3'],['row1cell1', 'row1cell2', 'row1cell3'],['row2cell1', 'row2cell2', 'row2cell3']]`
+ - Alternatively, the Excel service accepts an `HTMLTableElement` instead of an array, and will parse the table.
+ - The Excel service can generate a multi-sheet workbook - pass an array of objects, each containing a sheet name and data (array or HTML table).
+
 #### Merging Cells (Excel only)
 
 In order to merge cells, an array of `merges` can be passed in the `options` hash.
@@ -95,6 +97,10 @@ export default class MyComponent extends Component {
             ['Foo', 'Bar'],
             ['Baz', 'Foobar'],
           ],
+        },
+        {
+          name: 'HTML table',
+          data: document.querySelector('#data'),
         },
       ];
       this.excel.export(sheets, { multiSheet: true, fileName: 'test.xlsx' });

--- a/addon/services/excel.js
+++ b/addon/services/excel.js
@@ -7,6 +7,7 @@ const defaultConfig = {
   sheetName: 'Sheet1',
   fileName: 'export.xlsx',
   multiSheet: false,
+  tableParseOptions: {},
 };
 
 export default class ExcelService extends Service {
@@ -28,6 +29,13 @@ export default class ExcelService extends Service {
       }
       let epoch = Date.parse(v);
       return (epoch - new Date(Date.UTC(1899, 11, 30))) / (24 * 60 * 60 * 1000);
+    }
+
+    function sheet_from_data(data, options) {
+      if (data instanceof HTMLTableElement) {
+        return XLSX.utils.table_to_sheet(data, options.tableParseOptions);
+      }
+      return sheet_from_array_of_arrays(data);
     }
 
     function sheet_from_array_of_arrays(data) {
@@ -88,7 +96,7 @@ export default class ExcelService extends Service {
       // Add multiple worksheets to workbook
       data.forEach((sheet) => {
         wb.SheetNames.push(sheet.name);
-        wb.Sheets[sheet.name] = sheet_from_array_of_arrays(sheet.data);
+        wb.Sheets[sheet.name] = sheet_from_data(sheet.data, options);
         if (sheet.merges && sheet.merges.length) {
           wb.Sheets[sheet.name]['!merges'] = sheet.merges;
         }
@@ -96,7 +104,7 @@ export default class ExcelService extends Service {
     } else {
       // Add a single worksheet to workbook
       wb.SheetNames.push(options.sheetName);
-      wb.Sheets[options.sheetName] = sheet_from_array_of_arrays(data);
+      wb.Sheets[options.sheetName] = sheet_from_data(data, options);
       if (options.merges && options.merges.length) {
         wb.Sheets[options.sheetName]['!merges'] = options.merges;
       }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -33,7 +33,28 @@ export default class ApplicationController extends Controller {
     this.excel.export(data, { sheetName: 'demo', fileName: 'demo.xlsx' });
   }
 
+  @action downloadTableAsXLSX() {
+    this.excel.export(
+      document.querySelector('#demoTable1'),
+      { sheetName: 'Table 1', fileName: 'demo-table.xlsx' }
+    );
+  }
+
+  @action downloadTablesAsXLSX() {
+    let tables = [
+      {
+        name: 'Table 1',
+        data: document.querySelector('#demoTable1'),
+      },
+      {
+        name: 'Table 2',
+        data: document.querySelector('#demoTable2'),
+      },
+    ]
+    this.excel.export(tables, { multiSheet: true, fileName: 'demo-tables.xlsx' });
+  }
+
   @action downloadMultiSheetXLSX() {
-    this.excel.export(sheets, { multiSheet: true, fileName: 'demo.xlsx' });
+    this.excel.export(sheets, { multiSheet: true, fileName: 'demo-multisheet.xlsx' });
   }
 }

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>ember-spreadsheet-export demo</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,51 @@
-<h2 id="title">Welcome to Ember</h2>
+<h2 id="title">ember-spreadsheet-export demo</h2>
 
 <button type="button" {{on "click" this.downloadCSV}}>Download CSV</button>
 <button type="button" {{on "click" this.downloadXLSX}}>Download XLSX (Excel)</button>
-<button type="button" {{on "click" this.downloadMultiSheetXLSX}}>Download multi-sheet XLSX (Excel)</button>
+<button type="button" {{on "click" this.downloadMultiSheetXLSX}}>Download multi-sheet XLSX (Excel)</button><br>
+<button type="button" {{on "click" this.downloadTableAsXLSX}}>Download first HTML table as XLSX (Excel)</button>
+<button type="button" {{on "click" this.downloadTablesAsXLSX}}>Download both HTML tables as XLSX (Excel)</button>
 
+<table id="demoTable1">
+    <thead>
+        <tr>
+            <th>Column 1</th>
+            <th>Column 2</th>
+            <th>Column 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Foo</td>
+            <td>Bar</td>
+            <td>Baz</td>
+        </tr>
+        <tr>
+            <td colspan="2">Foobar</td>
+            <td>Baz</td>
+        </tr>
+    </tbody>
+</table>
+
+<table id="demoTable2">
+    <thead>
+        <tr>
+            <th>Column A</th>
+            <th>Column B</th>
+            <th>Column C</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>FooA</td>
+            <td>BarB</td>
+            <td>BazC</td>
+        </tr>
+        <tr>
+            <td>Foo1</td>
+            <td>Bar2</td>
+            <td>Baz3</td>
+        </tr>
+    </tbody>
+</table>
 {{outlet}}


### PR DESCRIPTION
Adds support for passing an `HTMLTableElement` as a sheet's data (either for single-sheet or multi-sheet workbooks).  Thanks to @colenso for the idea (in #9); I've opted to use `table_to_sheet` rather than `table_to_book` and integrate it such that a multi-sheet workbook can be generated from multiple HTML tables (or a mixture of HTML tables and data arrays).